### PR TITLE
FileDecryption.cs: Solves issue #28.

### DIFF
--- a/src/KryptorCLI/FileEncryption/FileDecryption.cs
+++ b/src/KryptorCLI/FileEncryption/FileDecryption.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text.RegularExpressions;
 
 /*
     Kryptor: A simple, modern, and secure encryption tool.
@@ -145,7 +144,7 @@ namespace KryptorCLI
         public static string GetOutputFilePath(string inputFilePath)
         {
             string outputFilePath = inputFilePath.Replace(Constants.EncryptedExtension, string.Empty);
-            return FileHandling.GetUniqueFilePath(Regex.Replace(outputFilePath, @"\(.*?\)", string.Empty));
+            return FileHandling.GetUniqueFilePath(outputFilePath);
         }
 
         private static void FileException(string inputFilePath, Exception ex)

--- a/src/KryptorCLI/FileEncryption/FileDecryption.cs
+++ b/src/KryptorCLI/FileEncryption/FileDecryption.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Security.Cryptography;
+using System.Text.RegularExpressions;
 
 /*
     Kryptor: A simple, modern, and secure encryption tool.
@@ -144,7 +145,8 @@ namespace KryptorCLI
         public static string GetOutputFilePath(string inputFilePath)
         {
             string outputFilePath = inputFilePath.Replace(Constants.EncryptedExtension, string.Empty);
-            return FileHandling.GetUniqueFilePath(outputFilePath);
+            string outputFilePathCleaned = Regex.Replace(outputFilePath, @"\(.*?\)", string.Empty);
+            return FileHandling.GetUniqueFilePath(outputFilePathCleaned);
         }
 
         private static void FileException(string inputFilePath, Exception ex)

--- a/src/KryptorCLI/FileEncryption/FileDecryption.cs
+++ b/src/KryptorCLI/FileEncryption/FileDecryption.cs
@@ -145,8 +145,7 @@ namespace KryptorCLI
         public static string GetOutputFilePath(string inputFilePath)
         {
             string outputFilePath = inputFilePath.Replace(Constants.EncryptedExtension, string.Empty);
-            string outputFilePathCleaned = Regex.Replace(outputFilePath, @"\(.*?\)", string.Empty);
-            return FileHandling.GetUniqueFilePath(outputFilePathCleaned);
+            return FileHandling.GetUniqueFilePath(Regex.Replace(outputFilePath, @"\(.*?\)", string.Empty));
         }
 
         private static void FileException(string inputFilePath, Exception ex)

--- a/src/KryptorCLI/FileEncryption/FileDecryption.cs
+++ b/src/KryptorCLI/FileEncryption/FileDecryption.cs
@@ -143,8 +143,7 @@ namespace KryptorCLI
 
         public static string GetOutputFilePath(string inputFilePath)
         {
-            string outputFilePath = inputFilePath.Replace(Constants.EncryptedExtension, string.Empty);
-            return FileHandling.GetUniqueFilePath(outputFilePath);
+            return FileHandling.GetUniqueDecryptedFilePath(inputFilePath);
         }
 
         private static void FileException(string inputFilePath, Exception ex)

--- a/src/KryptorCLI/FileEncryption/FileDecryption.cs
+++ b/src/KryptorCLI/FileEncryption/FileDecryption.cs
@@ -140,12 +140,13 @@ namespace KryptorCLI
                 FileException(inputFilePath, ex);
             }
         }
-
+        
         public static string GetOutputFilePath(string inputFilePath)
         {
-            return FileHandling.GetUniqueDecryptedFilePath(inputFilePath);
+            string outputFilePath = inputFilePath.Replace(Constants.EncryptedExtension, string.Empty);
+            return FileHandling.GetUniqueFilePath(outputFilePath);
         }
-
+        
         private static void FileException(string inputFilePath, Exception ex)
         {
             if (ex is ArgumentException)

--- a/src/KryptorCLI/GeneralPurpose/FileHandling.cs
+++ b/src/KryptorCLI/GeneralPurpose/FileHandling.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Linq;
 using Sodium;
-using System.Text.RegularExpressions;
 
 /*
     Kryptor: A simple, modern, and secure encryption tool.

--- a/src/KryptorCLI/GeneralPurpose/FileHandling.cs
+++ b/src/KryptorCLI/GeneralPurpose/FileHandling.cs
@@ -166,7 +166,26 @@ namespace KryptorCLI
             if (!File.Exists(filePath)) { return filePath; }
             int fileNumber = 1;
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
-            string fileExtension = Regex.Replace(Path.GetExtension(filePath), @"\(.*?\)", string.Empty);
+            string fileExtension = Path.GetExtension(filePath);
+            string directoryPath = Path.GetDirectoryName(filePath);
+            do
+            {
+                fileNumber++;
+                string newFileName = $"{fileNameWithoutExtension} ({fileNumber}){fileExtension}";
+                filePath = Path.Combine(directoryPath, newFileName);
+            }
+            while (File.Exists(filePath));
+            return filePath;
+        }
+
+        public static string GetUniqueDecryptedFilePath(string filePath)
+        {
+            if (!File.Exists(filePath)) { return filePath; }
+            int fileNumber = 1;
+            
+            string fileNameWithoutEncryptedExtension = filePath.Replace(Constants.EncryptedExtension, string.Empty);
+            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileNameWithoutEncryptedExtension);
+            string fileExtension = Regex.Replace(Path.GetExtension(fileNameWithoutEncryptedExtension), @"\(.*?\)", string.Empty);
             string directoryPath = Path.GetDirectoryName(filePath);
             do
             {

--- a/src/KryptorCLI/GeneralPurpose/FileHandling.cs
+++ b/src/KryptorCLI/GeneralPurpose/FileHandling.cs
@@ -163,35 +163,20 @@ namespace KryptorCLI
 
         public static string GetUniqueFilePath(string filePath)
         {
-            if (!File.Exists(filePath)) { return filePath; }
-            int fileNumber = 1;
-            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
             string fileExtension = Path.GetExtension(filePath);
-            string directoryPath = Path.GetDirectoryName(filePath);
-            do
+            if (!string.IsNullOrEmpty(fileExtension) && filePath.EndsWith(')') && filePath[^4].Equals(' ') && filePath[^3].Equals('(') && char.IsDigit(filePath[^2]))
             {
-                fileNumber++;
-                string newFileName = $"{fileNameWithoutExtension} ({fileNumber}){fileExtension}";
-                filePath = Path.Combine(directoryPath, newFileName);
+                filePath = filePath.Remove(startIndex: filePath.Length - 4);
             }
-            while (File.Exists(filePath));
-            return filePath;
-        }
-
-        public static string GetUniqueDecryptedFilePath(string filePath)
-        {
             if (!File.Exists(filePath)) { return filePath; }
-            int fileNumber = 1;
-            
-            string fileNameWithoutEncryptedExtension = filePath.Replace(Constants.EncryptedExtension, string.Empty);
-            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileNameWithoutEncryptedExtension);
-            string fileExtension = Regex.Replace(Path.GetExtension(fileNameWithoutEncryptedExtension), @"\(.*?\)", string.Empty);
+            int fileNumber = 2;
+            string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
             string directoryPath = Path.GetDirectoryName(filePath);
             do
             {
-                fileNumber++;
                 string newFileName = $"{fileNameWithoutExtension} ({fileNumber}){fileExtension}";
                 filePath = Path.Combine(directoryPath, newFileName);
+                fileNumber++;
             }
             while (File.Exists(filePath));
             return filePath;
@@ -200,13 +185,13 @@ namespace KryptorCLI
         public static string GetUniqueDirectoryPath(string directoryPath)
         {
             if (!Directory.Exists(directoryPath)) { return directoryPath; }
-            int directoryNumber = 1;
+            int directoryNumber = 2;
             string parentDirectory = Directory.GetParent(directoryPath).FullName;
             string directoryName = Path.GetFileName(directoryPath);
             do
             {
-                directoryNumber++;
                 directoryPath = Path.Combine(parentDirectory, $"{directoryName} ({directoryNumber})");
+                directoryNumber++;
             }
             while (Directory.Exists(directoryPath));
             return directoryPath;

--- a/src/KryptorCLI/GeneralPurpose/FileHandling.cs
+++ b/src/KryptorCLI/GeneralPurpose/FileHandling.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using Sodium;
+using System.Text.RegularExpressions;
 
 /*
     Kryptor: A simple, modern, and secure encryption tool.
@@ -165,7 +166,7 @@ namespace KryptorCLI
             if (!File.Exists(filePath)) { return filePath; }
             int fileNumber = 1;
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
-            string fileExtension = Path.GetExtension(filePath);
+            string fileExtension = Regex.Replace(Path.GetExtension(filePath), @"\(.*?\)", string.Empty);
             string directoryPath = Path.GetDirectoryName(filePath);
             do
             {


### PR DESCRIPTION
Solves [issue #28 ](https://github.com/samuel-lucas6/Kryptor/issues/28).

Reformatting decrypted file name using regex.
Now there is no need to worry about having bad extension names after decryption due to file duplication even if the filename is `Document.txt (2)(1).kryptor`